### PR TITLE
Several fixes

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -18,7 +18,11 @@ platforms:
     run_list:
     - recipe[apt]
 
-  - name: centos-6.5
+  - name: centos-6
+    run_list:
+    - recipe[apt]
+
+  - name: centos-7
     run_list:
     - recipe[apt]
 

--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ end
 
 group :test do
   gem 'foodcritic', '>=3.0.5'
+  gem 'cookstyle',  '~> 2.1'
   gem 'rubocop'
   gem 'rake'
   gem 'chefspec'

--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,7 @@ FoodCritic::Rake::LintTask.new(:foodcritic) do |t|
     tags: %w(~FC001 ~FC022 ~FC122),
     fail_tags: ['any'],
     # include_rules: '',
-    context: true
+    context: true,
   }
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 require 'foodcritic'
 require 'rspec/core/rake_task'
+require 'cookstyle'
 require 'rubocop/rake_task'
 require 'rake/dsl_definition'
 
@@ -9,7 +10,7 @@ RuboCop::RakeTask.new(:rubocop)
 desc 'Run Foodcritic lint checks'
 FoodCritic::Rake::LintTask.new(:foodcritic) do |t|
   t.options = {
-    tags: %w(~FC001 ~FC022),
+    tags: %w(~FC001 ~FC022 ~FC122),
     fail_tags: ['any'],
     # include_rules: '',
     context: true

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -23,6 +23,7 @@ default['crowd']['jvm']['support_args']    = ''
 
 # Database
 # TODO: support MySQL 5.0.37+, Oracle 10.2.0.1+ / 11.2.0.2.0+
+default['postgresql']['pg_gem']['version']             = '0.21.0'    # the 'database' cookbook doesn't work with 1.0.0
 default['postgresql']['config_pgtune']['db_type']      = 'web'       # postgresql tuning for web
 default['postgresql']['config_pgtune']['total_memory'] = '1048576kB' # limit max memory of the postgresql server to 1G
 default['crowd']['database']['type']                   = 'postgresql'

--- a/libraries/crowd.rb
+++ b/libraries/crowd.rb
@@ -2,7 +2,6 @@
 module Crowd
   # Crowd::Helpers module
   module Helpers
-
     def crowd_database_connection
       settings = merge_crowd_settings
 
@@ -86,64 +85,62 @@ module Crowd
       version = node['crowd']['version']
       sums = crowd_checksum_map[version]
 
-      fail "Crowd version #{version} is not supported by the cookbook" unless sums
+      raise "Crowd version #{version} is not supported by the cookbook" unless sums
 
       # Only standalone is supported by Crowd right now
       sums['tar']
     end
 
     # Returns SHA256 checksum map for Crowd artifacts
-    # rubocop:disable Metrics/MethodLength
     def crowd_checksum_map
       {
         '2.12.0' => {
-          'tar' => 'f53d9d6c1028c6f12ec4292579608fce5f926e40437d7795859e765584d2d6cd'
+          'tar' => 'f53d9d6c1028c6f12ec4292579608fce5f926e40437d7795859e765584d2d6cd',
         },
         '2.11.2' => {
-          'tar' => 'f6b539e100b09077e7448b3008364408d9437dd0f084ddd75fc7302549226c14'
+          'tar' => 'f6b539e100b09077e7448b3008364408d9437dd0f084ddd75fc7302549226c14',
         },
         '2.11.1' => {
-          'tar' => '472b9b4884591e87dec4ad4412dd2fc01a36e5eb2347ef7b3db9b16bcb4deb89'
+          'tar' => '472b9b4884591e87dec4ad4412dd2fc01a36e5eb2347ef7b3db9b16bcb4deb89',
         },
         '2.10.1' => {
-          'tar' => '86e9531c871be20761bcdfd6ea40d45ee74c7555609421283e69e1bfb1e784de'
+          'tar' => '86e9531c871be20761bcdfd6ea40d45ee74c7555609421283e69e1bfb1e784de',
         },
         '2.9.5' => {
-          'tar' => '647c7cc956c2ac774e87ab21faceae59267d81533808c9b72d29d7f03a30f020'
+          'tar' => '647c7cc956c2ac774e87ab21faceae59267d81533808c9b72d29d7f03a30f020',
         },
         '2.9.1' => {
-          'tar' => '07c5eb9eaaf51a208cd0e9f0062abff6d239b4a6225cf8154436178fadde3489'
+          'tar' => '07c5eb9eaaf51a208cd0e9f0062abff6d239b4a6225cf8154436178fadde3489',
         },
         '2.8.8' => {
-          'tar' => 'd2f095eac0ce0d778f556a2a7faa179eb008114015bd9dc2537707bfb020e3c0'
+          'tar' => 'd2f095eac0ce0d778f556a2a7faa179eb008114015bd9dc2537707bfb020e3c0',
         },
         '2.8.4' => {
-          'tar' => '7ae5a8c1928e997f8a220475db13f1fd374ee2b87e4a8d6cd5bb431378bfcf91'
+          'tar' => '7ae5a8c1928e997f8a220475db13f1fd374ee2b87e4a8d6cd5bb431378bfcf91',
         },
         '2.8.3' => {
-          'tar' => 'dabfde01366c1f72d50440e69d38a3a2a5092a4cba525b3987af8d53b11a402c'
+          'tar' => 'dabfde01366c1f72d50440e69d38a3a2a5092a4cba525b3987af8d53b11a402c',
         },
         '2.8.2' => {
-          'tar' => '250a46181cebe96624a59672b9f413d23e17195ca1fd6aafaff860951b5b89b4'
+          'tar' => '250a46181cebe96624a59672b9f413d23e17195ca1fd6aafaff860951b5b89b4',
         },
         '2.8.0' => {
-          'tar' => 'c857eb16f65ed99ab8b289fe671e3cea89140d42f85639304caa91a3ba9ade05'
+          'tar' => 'c857eb16f65ed99ab8b289fe671e3cea89140d42f85639304caa91a3ba9ade05',
         },
         '2.7.2' => {
-          'tar' => '49361f2c7cbd8035c2fc64dfff098eb5e51d754b5645425770da14fc577f1048'
+          'tar' => '49361f2c7cbd8035c2fc64dfff098eb5e51d754b5645425770da14fc577f1048',
         },
         '2.6.7' => {
-          'tar' => 'a40d2e3b5f14f44f1ced8046e42e1ea86475eab0cd4914486b4ad1bff79baf58'
+          'tar' => 'a40d2e3b5f14f44f1ced8046e42e1ea86475eab0cd4914486b4ad1bff79baf58',
         },
         '2.5.7' => {
-          'tar' => '95bdba3729b7b7e489a8b198315518bcce1c9cc1cbb95ebd68b29bd31cf0efa5'
+          'tar' => '95bdba3729b7b7e489a8b198315518bcce1c9cc1cbb95ebd68b29bd31cf0efa5',
         },
         '2.4.10' => {
-          'tar' => 'fcb7dde464068c82558bb6baf6d86542a3aec3a18d8fe965a230a42290cd7e11'
-        }
+          'tar' => 'fcb7dde464068c82558bb6baf6d86542a3aec3a18d8fe965a230a42290cd7e11',
+        },
       }
     end
-    # rubocop:enable Metrics/MethodLength
   end
 end
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,6 +8,8 @@ description      'Installs/Configures Atlassian Crowd'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '1.2.2'
 
+chef_version '>= 12.18', '< 14.0'
+
 recipe 'crowd::default',    'Installs/configures Atlassian CROWD'
 recipe 'crowd::standalone', 'Installs/configures CROWD via standalone archive'
 recipe 'crowd::database',   'Installs/configures MySQL/Postgres server, database, and user for CROWD'

--- a/recipes/apache2.rb
+++ b/recipes/apache2.rb
@@ -5,8 +5,8 @@
 # Copyright 2015, KLM Royal Dutch Airlines
 #
 
-node.set['apache']['listen'] = node['apache']['listen'] + ["*:#{node['crowd']['apache2']['port']}"] unless node['apache']['listen'].include?("*:#{node['crowd']['apache2']['port']}")
-node.set['apache']['listen'] = node['apache']['listen'] + ["*:#{node['crowd']['apache2']['ssl']['port']}"] unless node['apache']['listen'].include?("*:#{node['crowd']['apache2']['ssl']['port']}")
+node.normal['apache']['listen'] = node['apache']['listen'] + ["*:#{node['crowd']['apache2']['port']}"] unless node['apache']['listen'].include?("*:#{node['crowd']['apache2']['port']}")
+node.normal['apache']['listen'] = node['apache']['listen'] + ["*:#{node['crowd']['apache2']['ssl']['port']}"] unless node['apache']['listen'].include?("*:#{node['crowd']['apache2']['ssl']['port']}")
 
 include_recipe 'apache2'
 include_recipe 'apache2::mod_proxy'

--- a/recipes/configuration.rb
+++ b/recipes/configuration.rb
@@ -28,11 +28,11 @@ if node['crowd']['install_type'] == 'standalone'
     notifies :restart, 'service[crowd]', :delayed
   end
 
-  template "#{node['crowd']['pid']}" do
+  template node['crowd']['pid'] do
     source 'crowd.pid.erb'
     mode '0644'
     owner node['crowd']['user']
     group node['crowd']['user']
-    not_if { File.exist?("#{node['crowd']['pid']}") }
+    not_if { File.exist?(node['crowd']['pid']) }
   end
 end

--- a/recipes/standalone.rb
+++ b/recipes/standalone.rb
@@ -19,7 +19,7 @@ user node['crowd']['user'] do
   comment 'CROWD Service Account'
   home node['crowd']['home_path']
   shell '/bin/bash'
-  supports :manage_home => true
+  manage_home true
   system true
   action :create
 end


### PR DESCRIPTION
This addresses several changes upstream:
* `Fixnum`s cannot be compared with strings
* The Centos 6.5 bento box is no longer available
* Limit the `pg` gem to `v0.2.1`, since the newly-released `v1.0.0` has breaking changes in the (deprecated) `database` cookbook